### PR TITLE
chore(zeebe): update to Zeebe 0.12.1 and use single contact point

### DIFF
--- a/k8s-config-map/zeebe.yaml
+++ b/k8s-config-map/zeebe.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: zeebe
-        image: camunda/zeebe:0.12.0
+        image: camunda/zeebe:0.12.1
         ports:
         - containerPort: 26500
           name: gateway
@@ -33,13 +33,17 @@ spec:
           - name: MY_POD_NAME
             valueFrom:
               fieldRef:
-                fieldPath: metadata.name   
+                fieldPath: metadata.name
           - name: ZEEBE_CLUSTER_SIZE
             value: "3"
+          - name: ZEEBE_PARTITIONS_COUNT
+            value: "3"
+          - name: ZEEBE_REPLICATION_FACTOR
+            value: "3"
           - name: ZEEBE_CONTACT_POINTS
-            value: "zeebe-0.zeebe:26502, zeebe-1.zeebe:26502, zeebe-2.zeebe:26502"
-#          - name: ZEEBE_LOG_LEVEL
-#            value: debug
+            value: "zeebe-0.zeebe:26502"
+          - name: ZEEBE_LOG_LEVEL
+            value: info
         command:
           - "/bin/sh"
           - "-c"


### PR DESCRIPTION
Changes:
- use latest 0.12.1 patch release 
- only use first node as contact point, in a stateful set the nodes are rolled out one node after the other, so the first node is always available, multiple contact points is a buggy feature

Make sure to always delete the stateful set before applying changes, as otherwise kubernetes does an rolling upgrade which means new clean broker will join old dirty brokers, which can lead to various strange effects. Rolling upgrades are not supported at the moment.

Example command order
```
kubectl delete -f load-starter.yaml -f load-worker.yaml -f zeebe.yaml
kubectl apply -f zeebe.yaml
kubectl apply -f load-starter.yaml -f load-worker.yaml 
```
