### PR TITLE
chore(k8s-config-map): fix zeebe index name

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ gcloud container clusters delete zeebe-load
 kubectl exec -it zeebe-0 -- /bin/bash
 ```
 
-* Show Zeebe cluster topolgy (on Zeeeb pod):
+* Show Zeebe cluster topology (on Zeebe pod):
 ```
-ZB_BROKER_ADDR=zeebe-0.zeebe:26500 /usr/local/zeebe/bin/zbctl status
+zbctl status
 ```
 
 * Show log of Zeebe

--- a/k8s-config-map/operate-config.yaml
+++ b/k8s-config-map/operate-config.yaml
@@ -15,14 +15,12 @@ data:
         port: 9300
       zeebe:
         brokerContactPoint: zeebe-gateway:26500
-        topics:
-          - new-topic
         worker: operate
       zeebeElasticsearch:
         clusterName: elasticsearch-cluster
         host: elastic-gateway
         port: 9300
-        prefix: operate
+        prefix: zeebe
     logging:
       level:
         ROOT: INFO

--- a/k8s-config-map/zeebe-config.yaml
+++ b/k8s-config-map/zeebe-config.yaml
@@ -18,7 +18,7 @@ data:
       size = 1
 
       [exporters.args.index]
-      prefix = "operate"
+      prefix = "zeebe"
       createTemplate = true
       command = false
       event = true


### PR DESCRIPTION
- update zeebe/operate config to use `zeebe` prefix for elastic indices as
`operate` is used by operate itself
- update zbctl usage, `ZB_BROKER_ADDR` is not required anymore with 0.14.0